### PR TITLE
Externalize email settings into configuration

### DIFF
--- a/Interfaces/IEmailService.cs
+++ b/Interfaces/IEmailService.cs
@@ -1,0 +1,12 @@
+using InternetVotingApplication.Models;
+
+namespace InternetVotingApplication.Interfaces
+{
+    public interface IEmailService
+    {
+        void SendEmailAfterRegistration(Uzytkownik user);
+        void SendEmailVoteHash(GlosowanieWyborcze electionVoteDB, string userEmail);
+        void SendEmailChangePassword(string userEmail);
+        void SendNewPassword(string password, Uzytkownik user);
+    }
+}

--- a/Services/ElectionService.cs
+++ b/Services/ElectionService.cs
@@ -1,5 +1,4 @@
 ﻿using InternetVotingApplication.Blockchain;
-using InternetVotingApplication.ExtensionMethods;
 using InternetVotingApplication.Interfaces;
 using InternetVotingApplication.Models;
 using InternetVotingApplication.ViewModels;
@@ -11,9 +10,10 @@ using System.Threading.Tasks;
 
 namespace InternetVotingApplication.Services
 {
-    public class ElectionService(InternetVotingContext context) : IElectionService
+    public class ElectionService(InternetVotingContext context, IEmailService emailService) : IElectionService
     {
         private readonly InternetVotingContext _context = context;
+        private readonly IEmailService _emailService = emailService;
 
         public DataWyborowViewModel GetAllElections()
         {
@@ -102,7 +102,7 @@ namespace InternetVotingApplication.Services
 
             _context.AddRange(electionVoteDB, userVoiceDB);
             _context.SaveChanges();
-            Email.SendEmailVoteHash(electionVoteDB, userEmail);
+            _emailService.SendEmailVoteHash(electionVoteDB, userEmail);
 
             return electionVoteDB.Hash;
         }

--- a/Services/EmailService.cs
+++ b/Services/EmailService.cs
@@ -1,54 +1,52 @@
-﻿using InternetVotingApplication.Models;
+using InternetVotingApplication.Interfaces;
+using InternetVotingApplication.Models;
 using MailKit.Net.Smtp;
 using MailKit.Security;
+using Microsoft.Extensions.Configuration;
 using MimeKit;
 using MimeKit.Text;
 
-namespace InternetVotingApplication.ExtensionMethods
+namespace InternetVotingApplication.Services
 {
-    public static class Email
+    public class EmailService(IConfiguration configuration) : IEmailService
     {
-        private const string FromEmail = "aplikacjadoglosowania@gmail.com";
-        private const string SmtpServer = "smtp.ethereal.email";
-        private const int SmtpPort = 587;
-        private const string SmtpUser = "kariane91@ethereal.email";
-        private const string SmtpPass = "KwbBAKZ3Rbssk871tU";
+        private readonly IConfiguration _configuration = configuration;
 
-        public static void SendEmailAfterRegistration(Uzytkownik user)
+        public void SendEmailAfterRegistration(Uzytkownik user)
         {
             var body = $"<h2>Twoje konto <b>{user.Imie} {user.Nazwisko}</b> w aplikacji do głosowania zostało założone pomyślnie!</h2><br /><br />Naciśnij ten link aby aktywować konto<br /><a href='https://localhost:44342/Account/Activation/{user.KodAktywacyjny}'>Naciśnij aby aktywować konto.</a><br />";
             SendEmail(user.Email, "Link aktywacyjny do konta w aplikacji do głosowania", body);
         }
 
-        public static void SendEmailVoteHash(GlosowanieWyborcze electionVoteDB, string userEmail)
+        public void SendEmailVoteHash(GlosowanieWyborcze electionVoteDB, string userEmail)
         {
             var body = $"<h2>Hash twojego głosu: <b>{electionVoteDB.Hash}</b></h2></br> <p>Możesz sprawdzić poprawność swojego głosu w wyszukiwarce znajdującej się na stronie</p>";
             SendEmail(userEmail, "Dziękujemy za zagłosowanie w wyborach", body);
         }
 
-        public static void SendEmailChangePassword(string userEmail)
+        public void SendEmailChangePassword(string userEmail)
         {
             var body = "<h2>Twoje hasło zostało zmienione!</h2></br> <p>Jeśli otrzymałeś tą wiadomość a to nie ty dokonałeś zmiany hasła skontaktuj się z administratorem.</p>";
             SendEmail(userEmail, "Pomyślna zmiana hasła!", body);
         }
 
-        public static void SendNewPassword(string password, Uzytkownik user)
+        public void SendNewPassword(string password, Uzytkownik user)
         {
             var body = $"<h2>Twoje hasło zostało zresetowane i zastąpione nowym.!</h2></br> <p>Nowe hasło: {password}</p></br><p>Pamiętaj aby po zalogowaniu się tym hasłem zmienić je na własne nowe!</p>";
             SendEmail(user.Email, "Przypomnienie hasła!", body);
         }
 
-        private static void SendEmail(string toEmail, string subject, string body)
+        private void SendEmail(string toEmail, string subject, string body)
         {
             var email = new MimeMessage();
-            email.From.Add(MailboxAddress.Parse(FromEmail));
+            email.From.Add(MailboxAddress.Parse(_configuration["EmailSettings:FromEmail"]));
             email.To.Add(MailboxAddress.Parse(toEmail));
             email.Subject = subject;
             email.Body = new TextPart(TextFormat.Html) { Text = body };
 
             using var smtp = new SmtpClient();
-            smtp.Connect(SmtpServer, SmtpPort, SecureSocketOptions.StartTls);
-            smtp.Authenticate(SmtpUser, SmtpPass);
+            smtp.Connect(_configuration["EmailSettings:SmtpServer"], int.Parse(_configuration["EmailSettings:SmtpPort"]), SecureSocketOptions.StartTls);
+            smtp.Authenticate(_configuration["EmailSettings:SmtpUser"], _configuration["EmailSettings:SmtpPass"]);
             smtp.Send(email);
             smtp.Disconnect(true);
         }

--- a/Services/UserService.cs
+++ b/Services/UserService.cs
@@ -9,9 +9,10 @@ using BC = BCrypt.Net.BCrypt;
 
 namespace InternetVotingApplication.Services
 {
-    public class UserService(InternetVotingContext context) : IUserService
+    public class UserService(InternetVotingContext context, IEmailService emailService) : IUserService
     {
         private readonly InternetVotingContext _context = context;
+        private readonly IEmailService _emailService = emailService;
 
         public async Task<bool> RegisterAsync(Uzytkownik user)
         {
@@ -32,7 +33,7 @@ namespace InternetVotingApplication.Services
             _context.Uzytkowniks.Add(user);
             await _context.SaveChangesAsync();
 
-            Email.SendEmailAfterRegistration(user);
+            _emailService.SendEmailAfterRegistration(user);
             return true;
         }
 
@@ -74,7 +75,7 @@ namespace InternetVotingApplication.Services
             _context.Update(account);
             _context.SaveChanges();
 
-            Email.SendEmailChangePassword(userEmail);
+            _emailService.SendEmailChangePassword(userEmail);
             return true;
         }
 
@@ -108,7 +109,7 @@ namespace InternetVotingApplication.Services
             string newPassword = GeneratePassword.CreateRandomPassword(8);
             user.Haslo = BC.HashPassword(newPassword);
             await _context.SaveChangesAsync();
-            Email.SendNewPassword(newPassword, user);
+            _emailService.SendNewPassword(newPassword, user);
             return true;
         }
     }

--- a/Startup.cs
+++ b/Startup.cs
@@ -18,6 +18,7 @@ namespace InternetVotingApplication
         {
             var connectionString = Configuration.GetConnectionString("InternetVotingDBConnection");
             services.AddDbContext<InternetVotingContext>(options => options.UseSqlServer(connectionString));
+            services.AddTransient<IEmailService, EmailService>();
             services.AddTransient<IUserService, UserService>();
             services.AddTransient<IAdminService, AdminService>();
             services.AddTransient<IElectionService, ElectionService>();

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -5,5 +5,12 @@
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }
+  },
+  "EmailSettings": {
+    "FromEmail": "your-email@example.com",
+    "SmtpServer": "smtp.example.com",
+    "SmtpPort": 587,
+    "SmtpUser": "smtp-username",
+    "SmtpPass": "smtp-password"
   }
 }

--- a/appsettings.json
+++ b/appsettings.json
@@ -8,5 +8,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "EmailSettings": {
+    "FromEmail": "your-email@example.com",
+    "SmtpServer": "smtp.example.com",
+    "SmtpPort": 587,
+    "SmtpUser": "smtp-username",
+    "SmtpPass": "smtp-password"
+  }
 }


### PR DESCRIPTION
## Summary
- move SMTP credentials to `EmailSettings` section in config
- create `EmailService` that reads settings from `IConfiguration`
- inject `IEmailService` into user and election services and register with DI container
- replace sample SMTP credentials with placeholders in configuration files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc596d7688321b657a7567090c111